### PR TITLE
fix addr of parsing

### DIFF
--- a/crates/zirael_parser/src/parser/expr.rs
+++ b/crates/zirael_parser/src/parser/expr.rs
@@ -141,7 +141,7 @@ impl Parser<'_> {
       } else if self.eat(TokenType::Const) {
         Mutability::Const
       } else {
-        todo!("proper diagnostic")
+        Mutability::Const
       };
       let operand = self.parse_unary_expr();
       return Expr::new(

--- a/playground/src/index.zr
+++ b/playground/src/index.zr
@@ -9,4 +9,6 @@ pub func add(a: i32, b: i32) -> i32 {
 pub func test() {
     var a = identity(10);
     var b = add(10, "w");
+
+    var y = &b;
 }


### PR DESCRIPTION
before the addr of parsing stupidly panicked when there was no mutability modifier. now it defaults to const